### PR TITLE
Enable GoatCounter analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ analytics:
   google:
     id:
   goatcounter:
-    id:
+    id: senthilsiva
 
 # Comments via Giscus (GitHub Discussions)
 # Setup instructions:


### PR DESCRIPTION
Wires up privacy-friendly analytics. The slot was already present in `_config.yml`; this just fills in the site code.

## Change
- `_config.yml` → `analytics.goatcounter.id: senthilsiva`

Chirpy emits the GoatCounter snippet (`https://senthilsiva.goatcounter.com/count` via `gc.zgo.at/count.js`) **only in production builds**, so local `jekyll serve` won't record pageviews.

## Verification
- `JEKYLL_ENV=production bundle exec jekyll build` — clean; confirmed `data-goatcounter="https://senthilsiva.goatcounter.com/count"` renders in `_site`
- `htmlproofer` — passes

## After merge
- Visit the site, then check the GoatCounter dashboard for the pageview
- In GoatCounter **Settings → Site**, confirm the site domain is `www.senthilsiva.com` so pageviews aren't rejected on origin mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)