### PR TITLE
Enable Giscus comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,16 +43,16 @@ analytics:
 # Comments via Giscus (GitHub Discussions)
 # Setup instructions:
 # 1. Enable Discussions on your GitHub repo (Settings → General → Features)
-# 2. Visit https://giscus.app/ and select your repo: senthil1216/senthilsiva.github.io
+# 2. Visit https://giscus.app/ and select your repo: senthilsiva/senthilsiva.github.io
 # 3. Choose or create a category (e.g. "Blog Comments")
 # 4. Copy the repo_id and category_id below
 comments:
   provider: giscus
   giscus:
-    repo: senthil1216/senthilsiva.github.io
-    repo_id:          # e.g. R_kgDO... — get from https://giscus.app
-    category: Blog Comments
-    category_id:      # e.g. DIC_kwDO... — get from https://giscus.app
+    repo: senthilsiva/senthilsiva.github.io
+    repo_id: R_kgDOGfidnQ
+    category: General
+    category_id: DIC_kwDOGfidnc4C-rEX
     mapping: pathname
     strict: 0
     reactions_enabled: 1


### PR DESCRIPTION
Turns on GitHub Discussions–backed comments. The config slots already existed; this fills them in with the values from giscus.app.

## Changes (`_config.yml`)
- `comments.giscus.repo_id: R_kgDOGfidnQ`
- `comments.giscus.category_id: DIC_kwDOGfidnc4C-rEX`
- `comments.giscus.category: General`
- `comments.giscus.repo: senthilsiva/senthilsiva.github.io` (was `senthil1216/…`; corrected to the actual remote owner)

`comments: true` is already the post default, so both existing posts get the widget. Chirpy injects giscus client-side and syncs its theme with the site's light/dark toggle.

## Verification
- `JEKYLL_ENV=production bundle exec jekyll build` — clean; confirmed `repo_id`, `category_id`, and repo all render into the post pages
- `htmlproofer` — passes

## After merge
- Open a post and scroll to the bottom — the giscus comment box should load
- Posting a comment creates a Discussion under the **General** category in `senthilsiva/senthilsiva.github.io`
- Requires the giscus GitHub App to be installed on the repo (giscus.app prompts for this during setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)