### PR TITLE
Fix missing Bootstrap grid in production CSS (oversized homepage images)

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -1,7 +1,16 @@
 ---
 ---
 
-@use 'main';
+@use 'abstracts/variables' with (
+  $theme: '{{ site.theme_mode }}'
+);
+
+/* prettier-ignore */
+@use 'main
+{%- if jekyll.environment == 'production' -%}
+  .bundle
+{%- endif -%}
+';
 
 /* ============================================
    Typography: Lato + JetBrains Mono (user preference)


### PR DESCRIPTION
## The real root cause
The oversized homepage card images aren't about *which* image is used — it's a **CSS bug**. The site's stylesheet entrypoint `assets/css/jekyll-theme-chirpy.scss` had been reduced to `@use 'main';` (when custom fonts were added), which **drops the production CSS bundle**.

Chirpy's default entrypoint imports `main.bundle` in production, and `main.bundle` is what `@use`s **Bootstrap** (`vendors/bootstrap`) — the grid (`col-md-*`) and flex utilities (`d-flex`, `flex-md-row-reverse`). Without them:
- The card's `<div class="col-md-5">` (image) and `col-md-7` (text) have **no width rules** → both fall back to full-width blocks → the card stacks instead of going side-by-side.
- The preview image therefore renders **full width**, and `.preview-img { aspect-ratio: 40/21; width: 100% }` blows it up to ~700px tall on a wide screen.

This is why the image looked huge **even after** PR #22 swapped in the proper static poster — the poster was fine; the layout was broken.

## Fix
Restore the gem's default entrypoint logic:
```scss
@use 'abstracts/variables' with ($theme: '{{ site.theme_mode }}');
@use 'main{% if jekyll.environment == 'production' %}.bundle{% endif %}';
```
(custom fonts/styles below are unchanged).

## Verification
`JEKYLL_ENV=production bundle exec jekyll build` →
- Compiled CSS grows 70 KB → 110 KB.
- `col-md-5`, `col-md-7`, `flex-md-row-reverse`, `d-flex`, `g-0` are all **present** again.
- Custom Lato/JetBrains-Mono `@font-face`, tag pills, 72ch reading width, and theme variables all still compile.

After this deploys, homepage cards render compact side-by-side (small preview on the side, text beside it) instead of a full-width banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)